### PR TITLE
Set permissions for GITHUB_TOKEN in workflows

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -7,6 +7,12 @@ on:
     branches: [ "develop" ]
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
   develop:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,12 @@ on:
         description: 'Tag to create or update'
         required: true
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -104,7 +110,6 @@ jobs:
       - name: Create or Update Git Tag
         id: create_tag
         run: |
-          cd api-shared || exit 1
           TAG_NAME="${{ env.TAG_NAME }}"
           git tag -fa "$TAG_NAME" -m "Release $TAG_NAME"
 


### PR DESCRIPTION
Added permissions to the GITHUB_TOKEN configuration in both main and develop workflows to enable deployment to GitHub Pages. Also removed unnecessary directory change in the release job of main.yml.