### PR TITLE
Add GitHub credentials and release configuration

### DIFF
--- a/.github/workflows/githubPages.yml
+++ b/.github/workflows/githubPages.yml
@@ -72,6 +72,10 @@ jobs:
         run: |
           mkdir -p ~/.gradle
           echo "nvdApiKey=${{ secrets.NVD_API_KEY }}" >> ~/.gradle/gradle.properties
+          echo "githubUser=${{ secrets.PUBLISH_USER }}" >> ~/.gradle/gradle.properties
+          echo "githubToken=${{ secrets.RELEASE_GITHUB_TOKEN }}" >> ~/.gradle/gradle.properties
+          echo "releaseType=" >> ~/.gradle/gradle.properties
+          echo "org.gradle.internal.publish.checksums.insecure=true" >> ~/.gradle/gradle.properties
 
       - name: Install Pandoc
         run: sudo apt-get install -y pandoc


### PR DESCRIPTION
Include GitHub user and token in Gradle properties to facilitate authenticated publishing. Additionally, set up release type and allow insecure checksum publishing needed for Gradle builds.