### PR TITLE
Fix extraction syntax in GitHub workflows

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -52,11 +52,11 @@ jobs:
 
       - name: Extract version information
         run: |
-          majorEgkAndroid=$(grep '^\s*majorEgkAndroid\s*=' {print $2}' gradle.properties | sed 's/.*=\s*//')
+          majorEgkAndroid=$(grep '^\s*majorEgkAndroid\s*=' gradle.properties | sed 's/.*=\s*//')
           echo "Extracted majorSdk: $majorEgkAndroid"
-          minorEgkAndroid=$(grep '^\s*minorEgkAndroid\s*=' {print $2}' gradle.properties | sed 's/.*=\s*//')
+          minorEgkAndroid=$(grep '^\s*minorEgkAndroid\s*=' gradle.properties | sed 's/.*=\s*//')
           echo "Extracted minorSdk: $minorEgkAndroid"
-          patchEgkAndroid=$(grep '^\s*patchEgkAndroid\s*=' {print $2}' gradle.properties | sed 's/.*=\s*//')
+          patchEgkAndroid=$(grep '^\s*patchEgkAndroid\s*=' gradle.properties | sed 's/.*=\s*//')
           echo "Extracted patchSdk: $patchEgkAndroid"
           echo "MAJOR_EGK_API_VERSION=$majorEgkAndroid" >> $GITHUB_ENV
           echo "MINOR_EGK_API_VERSION=$minorEgkAndroid" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,11 +56,11 @@ jobs:
 
       - name: Extract version information
         run: |
-          majorEgkAndroid=$(grep '^\s*majorEgkAndroid\s*=' {print $2}' gradle.properties | sed 's/.*=\s*//')
+          majorEgkAndroid=$(grep '^\s*majorEgkAndroid\s*=' gradle.properties | sed 's/.*=\s*//')
           echo "Extracted majorSdk: $majorEgkAndroid"
-          minorEgkAndroid=$(grep '^\s*minorEgkAndroid\s*=' {print $2}' gradle.properties | sed 's/.*=\s*//')
+          minorEgkAndroid=$(grep '^\s*minorEgkAndroid\s*=' gradle.properties | sed 's/.*=\s*//')
           echo "Extracted minorSdk: $minorEgkAndroid"
-          patchEgkAndroid=$(grep '^\s*patchEgkAndroid\s*=' {print $2}' gradle.properties | sed 's/.*=\s*//')
+          patchEgkAndroid=$(grep '^\s*patchEgkAndroid\s*=' gradle.properties | sed 's/.*=\s*//')
           echo "Extracted patchSdk: $patchEgkAndroid"
           echo "MAJOR_EGK_API_VERSION=$majorEgkAndroid" >> $GITHUB_ENV
           echo "MINOR_EGK_API_VERSION=$minorEgkAndroid" >> $GITHUB_ENV


### PR DESCRIPTION
Corrected the syntax errors in the 'grep' and 'sed' commands for extracting version information from `gradle.properties`. This ensures proper version variables are set in both the `main.yml` and `develop.yml` workflows.

Relates-to: SDK-81