### PR TITLE
Update token for GitHub Pages deployment

### DIFF
--- a/.github/workflows/githubPages.yml
+++ b/.github/workflows/githubPages.yml
@@ -111,7 +111,7 @@ jobs:
         id: create_pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SDK_REPO_PAT }}
           sign-commits: true
           commit-message: "Update generated documentation"
           branch: update-pages-deployment


### PR DESCRIPTION
Replaced `GITHUB_TOKEN` with `SDK_REPO_PAT` in the `githubPages.yml` workflow. This change ensures proper authentication for creating pull requests to update generated documentation.

Relates-to: SDK-86