### PR TITLE
Update token for GitHub Pages deployment

### DIFF
--- a/.github/workflows/githubPages.yml
+++ b/.github/workflows/githubPages.yml
@@ -125,4 +125,4 @@ jobs:
         run: |
           gh pr merge ${{ steps.create_pr.outputs.pull-request-url }} --merge --admin
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SDK_REPO_PAT }}


### PR DESCRIPTION
Replaced `GITHUB_TOKEN` with `SDK_REPO_PAT` in the `githubPages.yml` workflow. This change ensures proper authentication for creating pull requests to update generated documentation.

Relates-to: SDK-86