### PR TITLE
Update AAR verification and upload paths in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,14 +100,14 @@ jobs:
       - name: Verify SDK AAR
         run: |
           echo "Verifying existence of AAR..."
-          ls -la framework/build/outputs/aar/
+          ls -la egk/build/outputs/aar/
 
       - name: Upload SDK AAR
         id: upload_sdk_aar
         uses: actions/upload-artifact@v4
         with:
           name: Link4health-SDK-Release
-          path: framework/build/outputs/aar
+          path: egk/build/outputs/aar
 
       - name: Set Tag Name
         id: set_tag_name


### PR DESCRIPTION
Updated the CI workflow configuration to verify and upload the AAR file from the correct path. Changed references from `framework/build/outputs/aar/` to `egk/build/outputs/aar/` to align with the new directory structure. This ensures the build process completes successfully and the AAR artifact is correctly identified and uploaded.

Relates-to: SDK-86