### PR TITLE
Update AAR path to use correct casing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Check if AAB und mapping files exist
         run: |
-          aar_path="downloaded_files/Link4health-SDK-${{ env.MAJOR_SDK_VERSION }}.${{ env.MINOR_SDK_VERSION }}.${{ env.PATCH_SDK_VERSION }}-${{ github.run_number }}-${{ env.SHORT_SHA }}.aar"
+          aar_path="downloaded_files/link4health-SDK-${{ env.MAJOR_SDK_VERSION }}.${{ env.MINOR_SDK_VERSION }}.${{ env.PATCH_SDK_VERSION }}-${{ github.run_number }}-${{ env.SHORT_SHA }}.aar"
           echo "Checking for AAR at path: $aar_path"
           if [[ -f "$aar_path" ]]; then
             echo "AAR file exists at $aar_path."


### PR DESCRIPTION
The 'Link4health' segment in the AAR path has been changed to 'link4health' to match the correct casing for the file directory. This ensures that the script correctly identifies the AAR file and can proceed without errors.

Relates-to: SDK-86