### PR TITLE
Update tag generation logic in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,7 +115,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "TAG_NAME=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
           else
-            TAG_NAME="v${{ env.MAJOR_EGK_API_VERSION }}.${{ env.MINOR_EGK_API_VERSION }}.${{ env.PATCH_EGK_API_VERSION }}"
+            TAG_NAME="v${{ env.MAJOR_EGK_VERSION }}.${{ env.MINOR_EGK_VERSION }}.${{ env.PATCH_EGK_VERSION }}"
             echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
           fi
 


### PR DESCRIPTION
Changed environment variable references from EGK_API_VERSION to EGK_VERSION to ensure correct tag name generation during workflow execution. This will standardize the tag naming convention across different events.

Relates-to: SDK-86