### PR TITLE
Remove redundant directory change in doc generation step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,7 +198,6 @@ jobs:
 
       - name: Generate Documentation Index HTML
         run: |
-          cd api-shared || exit 1
           ./gradlew generateDocIndexHtml
 
       - name: Setup Pages


### PR DESCRIPTION
The step to change the directory to 'api-shared' before generating the documentation index HTML has been removed. This change simplifies the workflow and eliminates unnecessary directory navigation. The `gradlew` command is now executed directly from the root directory.

Relates-to: SDK-81