### PR TITLE
Set 'github-pages' environment in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,9 @@ permissions:
 
 jobs:
   release:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: macos-latest
     steps:
       - name: Checkout Egk library


### PR DESCRIPTION
Added an environment section to the 'release' job in the GitHub Actions workflow. This specifies the environment name as 'github-pages' and sets the deployment output URL.

Relates-to: SDK-81