### PR TITLE
Disable GitHub Pages deployment steps in workflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,37 +195,37 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SDK_REPO_PAT }}
 
-      # Schritte für die Veröffentlichung auf GitHub Pages
-      - name: Install Pandoc
-        run: brew install pandoc
-
-      - name: Generate Documentation Index HTML
-        run: |
-          ./gradlew generateDocIndexHtml
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          # Upload the docs directory
-          path: 'docs'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create Pull Request for Documentation Updates
-        id: create_pr_docs
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sign-commits: true
-          commit-message: "Update generated documentation"
-          branch: pages-deployment
-          base: main
-          title: "Deploy Documentation and Reports"
-          body: "Automated deployment of documentation and reports"
+#      # Schritte für die Veröffentlichung auf GitHub Pages
+#      - name: Install Pandoc
+#        run: brew install pandoc
+#
+#      - name: Generate Documentation Index HTML
+#        run: |
+#          ./gradlew generateDocIndexHtml
+#
+#      - name: Setup Pages
+#        uses: actions/configure-pages@v5
+#
+#      - name: Upload artifact
+#        uses: actions/upload-pages-artifact@v3
+#        with:
+#          # Upload the docs directory
+#          path: 'docs'
+#
+#      - name: Deploy to GitHub Pages
+#        id: deployment
+#        uses: actions/deploy-pages@v4
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.SDK_REPO_PAT }}
+#
+#      - name: Create Pull Request for Documentation Updates
+#        id: create_pr_docs
+#        uses: peter-evans/create-pull-request@v7
+#        with:
+#          token: ${{ secrets.SDK_REPO_PAT }}
+#          sign-commits: true
+#          commit-message: "Update generated documentation"
+#          branch: pages-deployment
+#          base: main
+#          title: "Deploy Documentation and Reports"
+#          body: "Automated deployment of documentation and reports"


### PR DESCRIPTION
Commented out steps related to GitHub Pages deployment in the main workflow file. This includes installation of dependencies, generation of documentation, and the deployment process.

Relates-to: SDK-81