### PR TITLE
Add artifact name to docs upload in GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,6 +216,7 @@ jobs:
         with:
           # Upload the docs directory
           path: 'docs'
+          name: 'documentation-artifact'
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
This commit specifies the name 'documentation-artifact' for the docs directory upload step in the GitHub Actions workflow. This change helps in easily identifying the artifact during workflows and simplifies the deployment process.

Relates-to: SDK-81