### PR TITLE
Add artifact name to GitHub Pages deployment action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,6 +221,8 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: 'documentation-artifact'
         env:
           GITHUB_TOKEN: ${{ secrets.SDK_REPO_PAT }}
 


### PR DESCRIPTION
This change specifies 'documentation-artifact' as the artifact name in the GitHub Pages deployment step. It ensures that the deployment action correctly identifies and uses the designated artifact, improving the deployment process.

Relates-to: SDK-81