### PR TITLE
Update artifact name in workflow with dynamic run ID

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,13 +216,13 @@ jobs:
         with:
           # Upload the docs directory
           path: 'docs'
-          name: 'documentation-artifact'
+          name: 'documentation-artifact-${{ github.run_id }}'
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
         with:
-          artifact_name: 'documentation-artifact'
+          artifact_name: 'documentation-artifact-${{ github.run_id }}'
         env:
           GITHUB_TOKEN: ${{ secrets.SDK_REPO_PAT }}
 


### PR DESCRIPTION
Appended the GitHub run ID to the artifact name in the workflow file. This ensures unique artifact names for each run, preventing conflicts in continuous deployment scenarios.

Relates-to: SDK-81