### PR TITLE
Remove redundant AAR verification and upload steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,18 +106,6 @@ jobs:
         run: |
           ./gradlew :egk:publishLink4HealthEgkLibraryPublicationToLink4HealthNexusRepository
 
-      - name: Verify SDK AAR
-        run: |
-          echo "Verifying existence of AAR..."
-          ls -la egk/build/outputs/aar/
-
-      - name: Upload SDK AAR
-        id: upload_sdk_aar
-        uses: actions/upload-artifact@v4
-        with:
-          name: Link4health-SDK-Release
-          path: egk/build/outputs/aar
-
       - name: Set Tag Name
         id: set_tag_name
         run: |
@@ -170,32 +158,12 @@ jobs:
           echo "$release_notes" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      - name: Download Release AAR
-        uses: actions/download-artifact@v4
-        with:
-          name: Link4health-SDK-Release
-          path: downloaded_files/
-
-      - name: Display structure of downloaded files
-        run: ls -R downloaded_files
-
-      - name: Check if AAB und mapping files exist
-        run: |
-          aar_path="downloaded_files/link4health-egk-library-${{ env.MAJOR_EGK_VERSION }}.${{ env.MINOR_EGK_VERSION }}.${{ env.PATCH_EGK_VERSION }}-${{ github.run_number }}-${{ env.SHORT_SHA }}.aar"
-          echo "Checking for AAR at path: $aar_path"
-          if [[ -f "$aar_path" ]]; then
-            echo "AAR file exists at $aar_path."
-          else
-            echo "::error::AAR file does not exist."
-            exit 1
-          fi
-
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.TAG_NAME }}
           files: |
-            downloaded_files/*.aar
+            egk/build/outputs/aar/*.aar
           body: ${{ env.RELEASE_NOTES }}
         env:
           GITHUB_TOKEN: ${{ secrets.SDK_REPO_PAT }}
@@ -216,13 +184,10 @@ jobs:
         with:
           # Upload the docs directory
           path: 'docs'
-          name: 'documentation-artifact-${{ github.run_id }}'
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        with:
-          artifact_name: 'documentation-artifact-${{ github.run_id }}'
         env:
           GITHUB_TOKEN: ${{ secrets.SDK_REPO_PAT }}
 


### PR DESCRIPTION
Removed steps for verifying, uploading, and downloading SDK AAR within GitHub Actions workflow to streamline the CI/CD process. The publish and release steps now directly use the build output directory.

Relates-to: SDK-81