### PR TITLE
Update GitHub token usage in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,16 +189,16 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
         env:
-          GITHUB_TOKEN: ${{ secrets.SDK_REPO_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Pull Request for Documentation Updates
         id: create_pr_docs
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.SDK_REPO_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           sign-commits: true
           commit-message: "Update generated documentation"
-          branch: pages-deployment
-          base: main
+          branch: main
+          base: pages-deployment
           title: "Deploy Documentation and Reports"
           body: "Automated deployment of documentation and reports"


### PR DESCRIPTION
Replaced SDK_REPO_PAT with GITHUB_TOKEN for authentication in deployment and documentation PR creation steps. Also swapped the branch and base in the PR configuration to correct the deployment flow.

Relates-to: SDK-81