### PR TITLE
Update deployment branch for documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,7 +201,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sign-commits: true
           commit-message: "Update generated documentation"
-          branch: main
+          branch: update-gh-pages
           base: gh-pages
           title: "Deploy Documentation and Reports"
           body: "Automated deployment of documentation and reports"


### PR DESCRIPTION
Changed the branch for documentation deployment from 'main' to 'update-gh-pages' in the GitHub Actions workflow. This ensures automated deployments correctly target the 'gh-pages' branch for documentation and reports.

Relates-to: SDK-81