### PR TITLE
Fix typo in GitHub Actions merge step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -209,6 +209,6 @@ jobs:
       - name: Merge Pull Request
         if: steps.create_pr_docs.outputs.pull-request-url != ''
         run: |
-          gh pr merge ${{ steps.create_pr.outputs.pull-request-url }} --merge --admin
+          gh pr merge ${{ steps.create_pr_docs.outputs.pull-request-url }} --merge --admin
         env:
           GITHUB_TOKEN: ${{ secrets.SDK_REPO_PAT }}


### PR DESCRIPTION
Corrected the output reference for the 'gh pr merge' command in the GitHub Actions workflow configuration. This ensures the correct pull request URL is used during the merge process.

Relates-to: SDK-81